### PR TITLE
Replace copyright file search by path

### DIFF
--- a/lib/reader-10-Machine-readable-v1.sh
+++ b/lib/reader-10-Machine-readable-v1.sh
@@ -24,14 +24,7 @@
 #   http://dep.debian.net/deps/dep5/
 
 package="$1"
-copyrightfile=
-if [ -f "/usr/share/doc/$package/copyright" ]; then
-  copyrightfile="/usr/share/doc/$package/copyright"
-elif [ -f "/usr/share/doc/${package%:*}/copyright" ]; then
-  copyrightfile="/usr/share/doc/${package%:*}/copyright"
-else
-  exit 0  # no copyright file found
-fi
+copyrightfile="$2"
 
 format=$(awk '/^Format:/{print}/^$/{exit}' "$copyrightfile")
 [ -n "$format" ] || exit 0

--- a/lib/reader-30-fuzzy_common-licenses.sh
+++ b/lib/reader-30-fuzzy_common-licenses.sh
@@ -25,14 +25,7 @@
 set -e
 
 package="$1"
-copyrightfile=
-if [ -f "/usr/share/doc/$package/copyright" ]; then
-  copyrightfile="/usr/share/doc/$package/copyright"
-elif [ -f "/usr/share/doc/${package%:*}/copyright" ]; then
-  copyrightfile="/usr/share/doc/${package%:*}/copyright"
-else
-  exit 0  # no copyright file found
-fi
+copyrightfile="$2"
 
 result=$(grep -oP '/usr/share/common-licenses/[0-9A-Za-z_.+-]+[0-9A-Za-z+]' "$copyrightfile" | cut -d/ -f5- | sort -u)
 if [ -n "$result" ]; then

--- a/lib/reader-50-superfuzzy.sh
+++ b/lib/reader-50-superfuzzy.sh
@@ -25,14 +25,7 @@
 set -e
 
 package="$1"
-copyrightfile=
-if [ -f "/usr/share/doc/$package/copyright" ]; then
-  copyrightfile="/usr/share/doc/$package/copyright"
-elif [ -f "/usr/share/doc/${package%:*}/copyright" ]; then
-  copyrightfile="/usr/share/doc/${package%:*}/copyright"
-else
-  exit 0  # no copyright file found
-fi
+copyrightfile="$2"
 
 result=$(grep -Ewoi \
     -e '(4-?clause )?"?BSD"? licen[sc]es?' \

--- a/lib/reader-70-free-licence.sh
+++ b/lib/reader-70-free-licence.sh
@@ -25,14 +25,7 @@
 set -e
 
 package="$1"
-copyrightfile=
-if [ -f "/usr/share/doc/$package/copyright" ]; then
-  copyrightfile="/usr/share/doc/$package/copyright"
-elif [ -f "/usr/share/doc/${package%:*}/copyright" ]; then
-  copyrightfile="/usr/share/doc/${package%:*}/copyright"
-else
-  exit 0  # no copyright file found
-fi
+copyrightfile="$2"
 
 result=$(grep -e '^License:' -e '^Licence:' "$copyrightfile" | cut -d':' -f2-)
 if [ -n "$result" ]; then

--- a/lib/reader-99-dump-unreadable-file.sh
+++ b/lib/reader-99-dump-unreadable-file.sh
@@ -25,14 +25,7 @@
 set -e
 
 package="$1"
-copyrightfile=
-if [ -f "/usr/share/doc/$package/copyright" ]; then
-  copyrightfile="/usr/share/doc/$package/copyright"
-elif [ -f "/usr/share/doc/${package%:*}/copyright" ]; then
-  copyrightfile="/usr/share/doc/${package%:*}/copyright"
-else
-  exit 0  # no copyright file found
-fi
+copyrightfile="$2"
 
 #echo "$copyrightfile" >&2
 #head -n1 "$copyrightfile" >&2


### PR DESCRIPTION
This commit replaces the copyright file assertion by supplying it to the second argument.
We do so because we don't need to search for the copyright file.